### PR TITLE
[ads] 共通ヘッダを各タグへ付加

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,6 +315,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾_PC_インライン_300x250_1 枠ID：114874 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="e308516ebcbc358d7b793dd804c1861d" >
                                 <script type="text/javascript">
                                     microadCompass.queue.push({
@@ -428,6 +433,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾_PC_インライン_300x250_2 枠ID：114875 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="4443f95fba2b0617c7cb095a6620edeb" >
                                 <script type="text/javascript">
                                     microadCompass.queue.push({
@@ -526,6 +536,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾_SP_インライン_300x250 枠ID：114873 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="fba6d7ea8877e3c42db683efc68f59fc" >
                                 <script type="text/javascript">
                                     microadCompass.queue.push({
@@ -644,6 +659,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾_SP_インライン_300x250 枠ID：114870 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="788710e13be0b1befc9439243c8c8824" >
                                  <script type="text/javascript">
                                     microadCompass.queue.push({
@@ -758,6 +778,11 @@
                         <br>
                         <div class="content-center">
                             <!-- とどろき英数塾_PC_インライン_300x250_3 枠ID：114876 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="3b198de775259d0e8be2b38307a49e40" >
                                 <script type="text/javascript">
                                     microadCompass.queue.push({
@@ -768,6 +793,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾_SP_インライン2_300x250 枠ID：114871 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="6839f7184dda43ed81c3cad0be58cd0b" >
                                 <script type="text/javascript">
                                     microadCompass.queue.push({
@@ -893,6 +923,11 @@
                     <br>
                     <div class="content-center">
                         <!-- とどろき英数塾_PC_インライン_300x250_4 枠ID：114877 -->
+                        <script type="text/javascript">
+                            var microadCompass = microadCompass || {};
+                            microadCompass.queue = microadCompass.queue || [];
+                        </script>
+                        <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                         <div id="da1a7def1e68783333a75ae970b17f6c" >
                             <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -903,6 +938,11 @@
                     </div>
                     <div class="content-center">
                         <!-- とどろき英数塾_SP_インライン3_300x250 枠ID：114872 -->
+                        <script type="text/javascript">
+                            var microadCompass = microadCompass || {};
+                            microadCompass.queue = microadCompass.queue || [];
+                        </script>
+                        <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                          <div id="e81cd3b9076b71e2b1c9535a5a23e0ca" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({

--- a/index_old.html
+++ b/index_old.html
@@ -13,13 +13,6 @@
     <meta property="og:image" content="./img/Thumbnail.png">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="とどろき英数塾｜旧版ページ">
-    
-    <!-- とどろき英数塾 ヘッダー用共通コード -->
-    <script type="text/javascript">
-        var microadCompass = microadCompass || {};
-        microadCompass.queue = microadCompass.queue || [];
-    </script>
-    <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
 </head>
 <body id="top" class="u-fixed-bg">
     <div id="wrapper">
@@ -88,6 +81,11 @@
 
             <div class="content-center">
                 <!-- とどろき英数塾旧_PC_インライン_300x250_1 枠ID：114885 -->
+                <script type="text/javascript">
+                    var microadCompass = microadCompass || {};
+                    microadCompass.queue = microadCompass.queue || [];
+                </script>
+                <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                 <div id="281f04d8b389b1f69d5c31cdd9cb81b8" >
                     <script type="text/javascript">
                         microadCompass.queue.push({
@@ -99,6 +97,11 @@
 
             <div class="content-center">
                 <!-- とどろき英数塾旧_SP_インライン_300x250_1 枠ID：114878 -->
+                 <script type="text/javascript">
+                    var microadCompass = microadCompass || {};
+                    microadCompass.queue = microadCompass.queue || [];
+                </script>
+                <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                  <div id="9e60035c56bc85efd1c037c2d1d497f0" >
                     <script type="text/javascript">
                         microadCompass.queue.push({
@@ -224,6 +227,11 @@
                     <br>
                     <div class="content-center">
                         <!-- とどろき英数塾旧_SP_インライン_300x250_2 枠ID：114879 -->
+                         <script type="text/javascript">
+                            var microadCompass = microadCompass || {};
+                            microadCompass.queue = microadCompass.queue || [];
+                        </script>
+                        <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                         <div id="dbc4e740d5ac7c5b96f2ee624e15d340" >
                             <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -234,6 +242,11 @@
                     </div>
                     <div class="content-center">
                         <!-- とどろき英数塾旧_PC_インライン_300x250_2 枠ID：114886 -->
+                         <script type="text/javascript">
+                            var microadCompass = microadCompass || {};
+                            microadCompass.queue = microadCompass.queue || [];
+                        </script>
+                        <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                         <div id="fa5e170c79c42ae0f654b7f336bc2704" >
                           <script type="text/javascript">
                             microadCompass.queue.push({
@@ -321,6 +334,11 @@
                         <br>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_SP_インライン_300x250_3 枠ID：114880 -->
+                             <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="1a81dbb5c8c0ad05cad71cd0992e1a10" >
                                   <script type="text/javascript">
                                     microadCompass.queue.push({
@@ -331,6 +349,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_PC_インライン_300x250_3 枠ID：114887 -->
+                             <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="706f8d2bab1dfb45b47007056cc9212a" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -418,6 +441,11 @@
                         <br>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_PC_インライン_300x250_4 枠ID：114888 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="66dfe96acea93c51c93af5198d0088e1" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -433,6 +461,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_SP_インライン_300x250_4 枠ID：114881 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="bd9ee6cd8c4758e6bb1105439d5475ed" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -516,6 +549,11 @@
                         <br>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_PC_インライン_300x250_5 枠ID：114889 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="10ba28d5e602deb43ef8d1ed44562fe8" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -531,6 +569,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_SP_インライン_300x250_5 枠ID：114882 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                             <div id="49b8c6639571e0566b9376a3f55fded0" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -613,6 +656,11 @@
                         <br>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_SP_インライン_300x250_6 枠ID：114883 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                              <div id="430ae583d58966d6ad4165ab4ad42bbd" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -623,6 +671,11 @@
                         </div>
                         <div class="content-center">
                             <!-- とどろき英数塾旧_PC_インライン_300x250_6 枠ID：114890 -->
+                            <script type="text/javascript">
+                                var microadCompass = microadCompass || {};
+                                microadCompass.queue = microadCompass.queue || [];
+                            </script>
+                            <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                              <div id="5ce9b144d754bcbf7689a54d6244b4e4" >
                               <script type="text/javascript">
                                 microadCompass.queue.push({
@@ -716,6 +769,11 @@
                     <br>
                     <div class="content-center">
                         <!-- とどろき英数塾旧_SP_インライン_300x250_7 枠ID：114884 -->
+                        <script type="text/javascript">
+                            var microadCompass = microadCompass || {};
+                            microadCompass.queue = microadCompass.queue || [];
+                        </script>
+                        <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                          <div id="f5fac06ab4113f082f3e45b15cef1e4c" >
                           <script type="text/javascript">
                             microadCompass.queue.push({
@@ -726,6 +784,11 @@
                     </div>
                     <div class="content-center">
                         <!-- とどろき英数塾旧_PC_インライン_300x250_7 枠ID：114891 -->
+                         <script type="text/javascript">
+                            var microadCompass = microadCompass || {};
+                            microadCompass.queue = microadCompass.queue || [];
+                        </script>
+                        <script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
                          <div id="1c7f5c9e28c8bfa66d4e059001504638" >
                           <script type="text/javascript">
                             microadCompass.queue.push({


### PR DESCRIPTION
管理者へ問い合わせたところ、共通ヘッダとはhtmlヘッダへ置くものではなく、
各タグの前に共通して設置するタグという認識が正しい。設置場所を修正した。